### PR TITLE
Fix hassfest validation by using description placeholders for URLs

### DIFF
--- a/custom_components/higoal/config_flow.py
+++ b/custom_components/higoal/config_flow.py
@@ -64,6 +64,9 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                 },
             ),
+            description_placeholders={
+                "url": "https://github.com/Minitour/ha-higoal",
+            },
             errors=_errors,
         )
 

--- a/custom_components/higoal/translations/en.json
+++ b/custom_components/higoal/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "user": {
-                "description": "If you need help with the configuration have a look here: https://github.com/Minitour/ha-higoal",
+                "description": "If you need help with the configuration have a look here: {url}",
                 "data": {
                     "username": "Username",
                     "password": "Password"


### PR DESCRIPTION
## Summary

- Hassfest rejects raw URLs in translation strings. The config flow description in `translations/en.json` contained a hardcoded URL which caused the CI `[TRANSLATIONS]` validation to fail.
- Replaced the raw URL with a `{url}` placeholder and added `description_placeholders` in `config_flow.py` to supply the URL at runtime.

## Test plan

- [ ] Verify hassfest validation passes in CI
- [ ] Confirm the config flow still displays the help URL correctly

Made with [Cursor](https://cursor.com)