### PR TITLE
Fix cover percentage reading from wrong byte offset

### DIFF
--- a/custom_components/higoal/client/device.py
+++ b/custom_components/higoal/client/device.py
@@ -30,10 +30,10 @@ class Entity:
     def set_response(self, response: bytes):
         old_value = self._response or bytes([0] * 48)
         old_status = old_value[18 + self.id]
-        old_percentage = old_value[18 + self.id + 19]
+        old_percentage = old_value[18 + self.id + 16]
 
         new_status = response[18 + self.id]
-        new_percentage = response[18 + self.id + 19]
+        new_percentage = response[18 + self.id + 16]
         self._response = response
         if old_status != new_status or old_percentage != new_percentage:
             # something has changed in the entity
@@ -108,7 +108,7 @@ class Entity:
             action=action,
         )
         cmd = list(cmd)
-        cmd[18 + self.id + 19] = value
+        cmd[18 + self.id + 16] = value
         self.device.manager.send_command(bytes(cmd))
 
     def can_set_percentage(self) -> bool:
@@ -138,12 +138,7 @@ class Entity:
         if self.type not in {TYPE_SHUTTER, TYPE_DIMMER}:
             return None
         status = self._current_response()
-
-        value_offset = 18 + self.id + 16
-        if status[18 + self.id + 8] != 0:
-            value_offset = 18 + self.id + 19
-
-        value = max(min(status[value_offset], 100), 0)
+        value = max(min(status[18 + self.id + 16], 100), 0)
         return value / 100
 
     def _current_response(self, use_cache: bool = True) -> bytes:

--- a/custom_components/higoal/manifest.json
+++ b/custom_components/higoal/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Minitour/ha-higoal/issues",
   "requirements": ["requests>=2.32.5"],
-  "version": "1.1.9"
+  "version": "1.1.10"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,21 +75,16 @@ def shutter_next_is_switch(manager):
     return Device.init_from(data, manager)
 
 
-def build_status_response(entity_statuses: dict[int, int], entity_percentages: dict[int, int] | None = None) -> bytes:
+def build_status_response(entity_statuses: dict[int, int], percentages: dict[int, int] | None = None) -> bytes:
     """Build a 48-byte status response with given entity values.
 
     entity_statuses: {entity_id: status_byte}  (e.g. 255=ON, 240=OFF, 0=OFFLINE)
-    entity_percentages: {entity_id: percentage_byte}  (0-100)
-
-    The percentage() method reads from offset 18+id+19 only when the
-    selector byte at 18+id+8 is non-zero; otherwise it reads 18+id+16.
-    This helper sets the selector byte so the +19 path is used.
+    percentages: {entity_id: percentage_byte}  (0-100), placed at offset 18+id+16
     """
     data = bytearray(48)
     for eid, val in entity_statuses.items():
         data[18 + eid] = val
-    if entity_percentages:
-        for eid, val in entity_percentages.items():
-            data[18 + eid + 8] = 1    # selector byte → use +19 offset
-            data[18 + eid + 19] = val
+    if percentages:
+        for eid, val in percentages.items():
+            data[18 + eid + 16] = val
     return bytes(data)

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -104,6 +104,28 @@ class TestPercentage:
         assert device.entities[0].percentage() == 1.0
 
 
+    def test_issue_62_raw_diagnostics(self, manager):
+        """Regression test: raw bytes from issue #62 diagnostics dump.
+
+        The user's 4B panel had blinds at ~13% closed but HA showed 100% open.
+        Byte 34 (offset 18+0+16) = 13, byte 37 (offset 18+0+19) = 0.
+        The old code read byte 37 (0) instead of byte 34 (13).
+        """
+        raw = bytes([
+            187, 91, 0, 0, 0, 3, 1, 2, 1, 102, 35, 5, 0, 0, 20,
+            255, 240, 240, 240, 240, 0, 0, 240, 240, 240, 240,
+            30, 29, 0, 0, 0, 0, 0, 0,
+            13, 13, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+        ])
+        data = make_device_dict(button_names="Balcony shades;Balcony shades down", button_types="3,3")
+        device = Device.init_from(data, manager)
+        device.set_current_status_response(raw)
+
+        assert device.entities[0].percentage() == 0.13
+        assert device.entities[1].percentage() == 0.13
+
+
 class TestSetResponse:
     def test_change_detected(self, manager):
         data = make_device_dict(button_names="A", button_types="1")
@@ -122,5 +144,27 @@ class TestSetResponse:
         entity = device.entities[0]
 
         response = build_status_response({0: 240})
+        entity.set_response(response)
+        assert entity.set_response(response) is False
+
+    def test_percentage_change_detected(self, manager):
+        """set_response must detect percentage changes at offset 18+id+16."""
+        data = make_device_dict(button_names="Blinds;", button_types="3,3")
+        device = Device.init_from(data, manager)
+        entity = device.entities[0]
+
+        response1 = build_status_response({0: 240}, {0: 0})
+        entity.set_response(response1)
+
+        response2 = build_status_response({0: 240}, {0: 50})
+        assert entity.set_response(response2) is True
+
+    def test_percentage_no_change_not_detected(self, manager):
+        """No false positive when only unrelated bytes differ."""
+        data = make_device_dict(button_names="Blinds;", button_types="3,3")
+        device = Device.init_from(data, manager)
+        entity = device.entities[0]
+
+        response = build_status_response({0: 240}, {0: 25})
         entity.set_response(response)
         assert entity.set_response(response) is False


### PR DESCRIPTION
## Summary

- Fix cover percentage reading from wrong byte offset (`+19` instead of `+16`), which caused shutter position to be stuck at 100% in HA while the native app showed the correct value
- Fix `set_response()` change detection to monitor the correct offset, so HA is notified when the cover position changes
- Fix `set_percentage()` to write dimmer percentage to the correct command offset

## Root Cause

The 48-byte status response stores percentage data at offset `18 + id + 16` (bytes 34-41) for **all** entity types. This was confirmed by decompiling the native Higoal app, which splits the response into three cached blocks and reads percentage from `h.d(hostId)[buttonIndex - 1]` (= bytes 34-41) for both shutter and dimmer screens.

The old code used a runtime selector byte at offset `18 + id + 8` (bytes 26-33) to conditionally redirect the percentage read to offset `+19`. This secondary data block fluctuates independently of the actual percentage, causing intermittent stuck-at-100% position when the selector byte happened to be non-zero.

## Test plan

- [x] Existing tests updated and passing (70/70)
- [x] Regression test added using exact raw bytes from issue #62 diagnostics
- [x] Verified against two real device diagnostic dumps (fully open + partially closed)
- [x] CI passes

Closes #62
