### PR TITLE
fix(mq, manager): detect cloud zombies + tame boot-time send storm

### DIFF
--- a/custom_components/higoal/client/manager.py
+++ b/custom_components/higoal/client/manager.py
@@ -55,6 +55,12 @@ class Manager(MessageHandler):
         self.device_map = {}
         self.entity_listener = entity_listener
         self.offline_devices = {}
+        # Rate-limit offline-device re-polling. Without this, every received
+        # message triggers a status query for every offline device, which on
+        # boot (when all devices start offline) creates a self-inflicted
+        # send-buffer storm that the cloud cannot keep up with.
+        self._offline_check_interval = timedelta(seconds=30)
+        self._last_offline_check = datetime.now() - self._offline_check_interval
 
     def get_devices(self):
         self.api.sign_in()
@@ -102,8 +108,12 @@ class Manager(MessageHandler):
             self.send_command(device.status_command())
 
     def check_offline_devices(self):
+        now = datetime.now()
+        if now - self._last_offline_check < self._offline_check_interval:
+            return
+        self._last_offline_check = now
         for offline_device in self.offline_devices.values():
-            offline_device.last_update = datetime.now()
+            offline_device.last_update = now
             self.send_command(offline_device.device.status_command())
 
     def on_receive(self, message: Message):

--- a/custom_components/higoal/client/mq.py
+++ b/custom_components/higoal/client/mq.py
@@ -114,6 +114,21 @@ class MessageBroker(threading.Thread):
                     # Create a fresh socket each attempt
                     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     self.socket.settimeout(10.0)
+                    # TCP keepalive + user-timeout: detect zombie connections.
+                    # The Higoal cloud occasionally stops responding without
+                    # closing the socket; without these the OS waits ~15 min
+                    # before declaring the peer dead, leaving the integration
+                    # stuck with entities unresponsive.
+                    self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+                    if hasattr(socket, "TCP_KEEPIDLE"):
+                        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+                    if hasattr(socket, "TCP_KEEPINTVL"):
+                        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+                    if hasattr(socket, "TCP_KEEPCNT"):
+                        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)
+                    if hasattr(socket, "TCP_USER_TIMEOUT"):
+                        # Force-fail the socket if data sits unacked >60s.
+                        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_USER_TIMEOUT, 60_000)
                     self.socket.connect((self.host, self.port))
                     self.socket.settimeout(None)
 


### PR DESCRIPTION
Heya, your integration is a godsend! Here are two fixes made by Claude under my supervision to fix disconnections/non-responsiveness. It generated the rest of the PR description.

## Summary

Two related stability fixes for cloud-side flakiness. Both surfaced on a 10-device account where entities would go unresponsive within ~1 minute of HA start, commands optimistically committed then reverted, and the integration never self-recovered.

### 1. `mq.py` — detect zombie connections (TCP keepalive + USER_TIMEOUT)

The Higoal cloud occasionally stops responding on the message-broker socket without closing the TCP connection. The receive loop in `MessageBroker.run()` then blocks indefinitely on `socket.recv()`, the existing `on_disconnect()` reconnect logic never fires, and HA sees entities as unavailable / sees commands revert because no confirming
status update arrives.

Observed with `ss -tno`: socket stayed `ESTABLISHED` with 480+ bytes stuck in the kernel send queue and the retransmit timer ticking, while the application thought everything was healthy. Linux's default `tcp_retries2` (15) means the kernel waits ~15 minutes before declaring the peer dead.

Fix: set socket-level options immediately after socket creation, before `connect()`:

- `SO_KEEPALIVE` on, with `TCP_KEEPIDLE=60s`, `TCP_KEEPINTVL=10s`, `TCP_KEEPCNT=5` → silent peer detected in ~110s.
- `TCP_USER_TIMEOUT=60s` → force-fail the socket if any sent data remains unacked beyond 60s. Critical for the "stuck send queue" case since keepalive only probes when the socket is idle in *both* directions.

`hasattr(socket, ...)` guards keep this safe on non-Linux platforms.

### 2. `manager.py` — rate-limit `check_offline_devices` (boot-time storm)

Every incoming MQ message calls `check_offline_devices`, which sends a status query for every device still in `offline_devices`. At startup all devices begin in that set (line 72), so the first arriving response triggers N outgoing queries — each racing for socket bandwidth against the next inbound response. The longer the storm continues, the harder the cloud falls behind.

On a 10-device account I observed ~3000 outgoing commands in the first 30s (3× inbound), send queue persistently 480–768 bytes, and boot status convergence taking ~60s instead of ~5. The pile-up compounds with the zombie-connection case, extending recovery further.

Fix: throttle `check_offline_devices` to a 30-second cooldown via an instance-level timestamp. Devices that don't answer the initial query in `refresh()` get retried after the cooldown on the next inbound, rather than on every single packet.

## Behavior after

- `ss -tno` shows `timer:(keepalive,Ns,0)` once the MQ socket is idle.
- Send/receive ratio settles near 1:1 after initial boot burst.
- Simulated cloud stall: socket force-closes within ~60s and the
  existing reconnect chain runs cleanly.

## Test plan
- [x] Connection stays healthy under normal cloud behavior
- [x] Cloud-stall scenario: socket fails within ~60s, integration reconnects automatically
- [x] Initial boot of 10-device account: no piled-up sends in `ss -tno`
- [x] Genuinely offline devices still get retried periodically (every 30s on next inbound)
- [x] No regression in initial connect path or normal entity updates

---

🤖 Opened using [Claude Code](https://claude.com/claude-code)