### PR TITLE
Improve Higoal entity fallback names and startup availability

### DIFF
--- a/custom_components/higoal/client/device.py
+++ b/custom_components/higoal/client/device.py
@@ -27,7 +27,18 @@ class Entity:
     def response(self):
         return self._response
 
+    @property
+    def display_name(self) -> str:
+        """Return a stable Home Assistant display name for this entity."""
+        name = (self.name or "").strip()
+        if name:
+            return name
+
+        device_name = (self.device.name or "").strip() or self.device.id
+        return f"{device_name} channel {self.id + 1}"
+
     def set_response(self, response: bytes):
+        first_response = self._response is None
         old_value = self._response or bytes([0] * 48)
         old_status = old_value[18 + self.id]
         old_percentage = old_value[18 + self.id + 16]
@@ -35,6 +46,8 @@ class Entity:
         new_status = response[18 + self.id]
         new_percentage = response[18 + self.id + 16]
         self._response = response
+        if first_response:
+            return True
         if old_status != new_status or old_percentage != new_percentage:
             # something has changed in the entity
             return True
@@ -150,7 +163,8 @@ class Entity:
         return bytes([0] * 48)
 
     def get_related_entity(self) -> Optional["Entity"]:
-        """Return the paired shutter entity using hardware index pairing.
+        """
+        Return the paired shutter entity using hardware index pairing.
 
         Shutter buttons are paired in fixed hardware pairs: (0,1), (2,3), (4,5), (6,7).
         Only the open button (even 0-based id) should request its partner (the close
@@ -181,7 +195,7 @@ class Device:
     mac: str
     version: str
     entities: list[Entity] = field(repr=False)
-    manager: 'Manager' = field(repr=False)
+    manager: "Manager" = field(repr=False)
     _status: bytes = field(repr=False, default=None)
 
     @property
@@ -208,7 +222,9 @@ class Device:
             entities=entities,
             manager=manager,
         )
-        for i, (button_name, button_type) in enumerate(zip(button_names, button_types, strict=False)):
+        for i, (button_name, button_type) in enumerate(
+            zip(button_names, button_types, strict=False)
+        ):
             button_type = int(button_type)
             if button_type == 0:
                 continue
@@ -221,7 +237,12 @@ class Device:
     @property
     def identifier(self):
         status_command = self.status_command()
-        return status_command[9], status_command[10], status_command[11], status_command[12]
+        return (
+            status_command[9],
+            status_command[10],
+            status_command[11],
+            status_command[12],
+        )
 
     def status_command(self) -> bytes:
         """
@@ -275,7 +296,10 @@ class DeviceRepository:
                 "content-type": "application/x-www-form-urlencoded; charset=utf-8"
             }
             response = self.manager.api.session.request(
-                "POST", f"{self.manager.api.url}/get_host_list", data=payload, headers=headers
+                "POST",
+                f"{self.manager.api.url}/get_host_list",
+                data=payload,
+                headers=headers,
             )
             body = response.json()
             devices.extend(body.get("repData", []))

--- a/custom_components/higoal/entity.py
+++ b/custom_components/higoal/entity.py
@@ -1,18 +1,20 @@
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity as HomeAssistantEntity
-from .const import DOMAIN, HIGOAL_HA_SIGNAL_UPDATE_ENTITY
+
 from .client.device import Entity
+from .const import DOMAIN, HIGOAL_HA_SIGNAL_UPDATE_ENTITY
 
 
 class BaseHigoalEntity(HomeAssistantEntity):
-
-    def __init__(self, entity: Entity):
+    def __init__(self, entity: Entity) -> None:
         self.entity = entity
         self._attr_unique_id = f"higoal:{entity.device.id}:{entity.id}"
-        self._attr_name = entity.name or "Higoal Entity"
+        self._attr_name = entity.display_name
 
     @property
-    def available(self):
+    def available(self) -> bool:
+        if self.entity.response is None:
+            return True
         return self.entity.is_online()
 
     @property
@@ -36,6 +38,6 @@ class BaseHigoalEntity(HomeAssistantEntity):
         )
 
     async def _handle_state_update(
-            self, updated_status_properties: list[str] | None
+        self, updated_status_properties: list[str] | None
     ) -> None:
         self.async_write_ha_state()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,7 +1,7 @@
 """Tests for Device.init_from and entity construction."""
 
-from client.device import Device, Entity, TYPE_SWITCH, TYPE_DIMMER, TYPE_SHUTTER
-from conftest import make_device_dict, make_manager_stub
+from client.device import TYPE_DIMMER, TYPE_SHUTTER, TYPE_SWITCH, Device
+from conftest import make_device_dict
 
 
 class TestDeviceInitFrom:
@@ -45,6 +45,28 @@ class TestDeviceInitFrom:
         assert device.entities[3].name == ""
         assert device.entities[3].type == TYPE_SHUTTER
 
+    def test_blank_entity_name_uses_device_channel_fallback(self, manager):
+        data = make_device_dict(
+            name="Study Lights",
+            button_names=";;",
+            button_types="0,1,1",
+        )
+        device = Device.init_from(data, manager)
+
+        assert device.entities[0].display_name == "Study Lights channel 2"
+        assert device.entities[1].display_name == "Study Lights channel 3"
+
+    def test_blank_entity_name_uses_device_id_when_device_name_is_blank(self, manager):
+        data = make_device_dict(
+            device_id="ZCLCBZ",
+            name=" ",
+            button_names="",
+            button_types="1",
+        )
+        device = Device.init_from(data, manager)
+
+        assert device.entities[0].display_name == "ZCLCBZ channel 1"
+
     def test_type_zero_buttons_are_skipped(self, manager):
         data = make_device_dict(
             button_names="A;;B",
@@ -75,14 +97,20 @@ class TestDeviceInitFrom:
 
 
 class TestDeviceStatusResponse:
-    def test_set_current_status_response_returns_changed_entities(self, four_button_device, manager):
+    def test_set_current_status_response_returns_changed_entities(
+        self, four_button_device, manager
+    ):
         from conftest import build_status_response
 
         response = build_status_response({0: 255})
         changed = four_button_device.set_current_status_response(response)
 
-        assert len(changed) == 1
-        assert changed[0].id == 0
+        assert [entity.id for entity in changed] == [0, 1, 2, 3]
+
+        response = build_status_response({0: 240, 1: 255})
+        changed = four_button_device.set_current_status_response(response)
+
+        assert [entity.id for entity in changed] == [0, 1]
 
     def test_identical_response_returns_empty(self, four_button_device, manager):
         from conftest import build_status_response

--- a/tests/test_entity_state.py
+++ b/tests/test_entity_state.py
@@ -138,6 +138,15 @@ class TestSetResponse:
         response2 = build_status_response({0: 255})
         assert entity.set_response(response2) is True
 
+    def test_first_response_detected_even_when_status_is_zero(self, manager):
+        data = make_device_dict(button_names="A", button_types="1")
+        device = Device.init_from(data, manager)
+        entity = device.entities[0]
+
+        response = build_status_response({0: 0})
+
+        assert entity.set_response(response) is True
+
     def test_no_change_detected(self, manager):
         data = make_device_dict(button_names="A", button_types="1")
         device = Device.init_from(data, manager)

--- a/tests/test_homeassistant_entity.py
+++ b/tests/test_homeassistant_entity.py
@@ -1,0 +1,79 @@
+"""Tests for the Home Assistant entity wrapper."""
+
+# ruff: noqa: ANN001, ANN201, ARG005, D103, INP001, S101, SLF001
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+from client.device import Device
+from conftest import build_status_response, make_device_dict
+
+
+def load_entity_module(monkeypatch):
+    """Load the entity module with minimal Home Assistant stubs."""
+    package_name = "_higoal_test"
+    component_path = (
+        Path(__file__).resolve().parents[1] / "custom_components" / "higoal"
+    )
+
+    homeassistant = types.ModuleType("homeassistant")
+    helpers = types.ModuleType("homeassistant.helpers")
+    dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+    helper_entity = types.ModuleType("homeassistant.helpers.entity")
+    higoal_package = types.ModuleType(package_name)
+
+    class HomeAssistantEntity:
+        pass
+
+    dispatcher.async_dispatcher_connect = lambda *args, **kwargs: None
+    helper_entity.Entity = HomeAssistantEntity
+    higoal_package.__path__ = [str(component_path)]
+
+    monkeypatch.setitem(sys.modules, "homeassistant", homeassistant)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.dispatcher", dispatcher)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", helper_entity)
+    monkeypatch.setitem(sys.modules, package_name, higoal_package)
+
+    sys.modules.pop(f"{package_name}.entity", None)
+    return importlib.import_module(f"{package_name}.entity")
+
+
+def test_entity_uses_display_name(monkeypatch, manager):
+    entity_module = load_entity_module(monkeypatch)
+    data = make_device_dict(
+        name="Study Lights",
+        button_names="",
+        button_types="1",
+    )
+    device = Device.init_from(data, manager)
+
+    ha_entity = entity_module.BaseHigoalEntity(device.entities[0])
+
+    assert ha_entity._attr_name == "Study Lights channel 1"
+
+
+def test_entity_available_before_first_status_response(monkeypatch, manager):
+    entity_module = load_entity_module(monkeypatch)
+    data = make_device_dict(button_names="Light", button_types="1")
+    device = Device.init_from(data, manager)
+
+    ha_entity = entity_module.BaseHigoalEntity(device.entities[0])
+
+    assert ha_entity.available is True
+    assert manager.sent_commands == []
+
+
+def test_entity_unavailable_after_offline_status_response(monkeypatch, manager):
+    entity_module = load_entity_module(monkeypatch)
+    data = make_device_dict(button_names="Light", button_types="1")
+    device = Device.init_from(data, manager)
+    device.set_current_status_response(build_status_response({0: 0}))
+
+    ha_entity = entity_module.BaseHigoalEntity(device.entities[0])
+
+    assert ha_entity.available is False


### PR DESCRIPTION
## Summary
- generate deterministic display names for active Higoal channels with blank button names
- keep entities available while waiting for their first status response instead of treating the all-zero placeholder as offline
- add regression coverage for fallback names and Home Assistant entity availability

Closes #65.
Closes #66.

## Testing
- uv --cache-dir .uv-cache run --extra test pytest
- uv --cache-dir .uv-cache run --extra test --with ruff ruff format custom_components/higoal/client/device.py custom_components/higoal/entity.py tests/test_device.py tests/test_homeassistant_entity.py

## Notes
I also ran the repository lint script via uv: uv --cache-dir .uv-cache run --extra test --with ruff bash scripts/lint. It reformatted files but then failed on existing repo-wide lint violations unrelated to this PR, so unrelated formatter churn was reverted and only the touched files remain formatted.