### PR TITLE
Raise ConfigEntryNotReady when Higoal cloud is unreachable at setup

### DIFF
--- a/custom_components/higoal/__init__.py
+++ b/custom_components/higoal/__init__.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from requests.exceptions import RequestException
+
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
@@ -68,7 +71,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: HigoalConfigEntry) -> bo
     )
 
     # Get all devices
-    await hass.async_add_executor_job(manager.get_devices)
+    try:
+        await hass.async_add_executor_job(manager.get_devices)
+    except RequestException as err:
+        # The Higoal cloud (server.higoal.net) was unreachable — e.g. DNS not
+        # available yet during a cold boot, or a transient network blip. Raise
+        # ConfigEntryNotReady so HA retries setup with backoff, instead of
+        # leaving the entry permanently failed until a manual reload.
+        raise ConfigEntryNotReady(f"Unable to reach Higoal cloud: {err}") from err
 
     # Connection is successful, store the manager & listener
     entry.runtime_data = IntegrationData(manager=manager, listener=device_listener)


### PR DESCRIPTION
## Problem

`async_setup_entry` calls `manager.get_devices()` (→ `api.sign_in()`) with no error handling, so any `requests` transport failure propagates raw out of setup. Home Assistant then marks the config entry as a **permanent setup error with no retry**.

This bites on a cold boot where DNS isn't up yet — e.g. a power outage brings the DNS resolver and HA back up together. `sign_in()` hits a `NameResolutionError`/`ConnectionError`, and the integration stays dead until a **manual reload**, even after connectivity recovers:

```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='server.higoal.net', port=8143):
  Max retries exceeded with url: /login (Caused by NameResolutionError(... [Errno -3] Try again))
  File ".../higoal/__init__.py", line 71, in async_setup_entry
  File ".../higoal/client/manager.py", line 66, in get_devices
  File ".../higoal/client/api.py", line 60, in sign_in
```

Other cloud integrations raise `ConfigEntryNotReady` in this situation and self-heal; higoal didn't.

## Fix

Catch `requests.exceptions.RequestException` around `get_devices()` and re-raise as `ConfigEntryNotReady`, so HA retries setup with backoff and recovers automatically once the cloud is reachable.

Scoped deliberately: only transport-level failures are converted. Auth/token errors (`RuntimeError` from `sign_in`) are left untouched.

## Testing

`python -m py_compile` passes. I don't have the full HA test env wired up locally to run the suite; existing tests under `tests/` don't exercise `async_setup_entry`. Happy to add a setup-retry test if you'd like one.